### PR TITLE
Added a priority for the snippets-source provider.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -312,7 +312,13 @@ export async function activate(context: ExtensionContext): Promise<API> {
   }, { silent: true, sync: false, cancel: true }))
 
   let languageProvider = new LanguageProvider(channel, trace)
-  subscriptions.push(languages.registerCompletionItemProvider('snippets-source', 'S', ['snippets'], languageProvider, ['$']))
+  subscriptions.push(languages.registerCompletionItemProvider(
+    'snippets-source',
+    'S',
+    ['snippets'],
+    languageProvider,
+    ['$'],
+    configuration.get<number>('priority', 90)));
   subscriptions.push(statusItem)
   subscriptions.push(channel)
   subscriptions.push(listManager.registerList(new SnippetsList(workspace.nvim as any, manager, mru)))


### PR DESCRIPTION
Right now coc-snippets registers two providers, `snippets` and `snippets-source`, only `snippets` was using the `snippets.priority` config key to set a priority.