### PR TITLE
avoid string escape in python input

### DIFF
--- a/src/ultisnipsProvider.ts
+++ b/src/ultisnipsProvider.ts
@@ -189,7 +189,7 @@ export class UltiSnippetsProvider extends BaseProvider {
       pyCodes.push(`snip = SnippetUtil('${ind}', ${start}, ${end}, context)`)
       if (originRegex) {
         pyCodes.push(`pattern = re.compile(r"${originRegex.replace(/"/g, '\\"')}")`)
-        pyCodes.push(`match = pattern.search("${line.replace(/"/g, '\\"')}")`)
+        pyCodes.push(`match = pattern.search(r"${line.replace(/"/g, '\\"')}")`)
       }
       try {
         await nvim.command(`${this.pyMethod} ${pyCodes.join('\n')}`)


### PR DESCRIPTION
Currently sequences like `\r` in a snippet match cause issues for python UltiSnips since the input isn't put in a raw string.

Example:
```snippets
snippet '.*test' "Test" irA
`!p snip.rv = match.string`
endsnippet
```
results in
![](https://i.imgur.com/vRSrmpi.gif)

This fixes the issue.