### PR TITLE
improve vscode snippet loader

### DIFF
--- a/src/textmateProvider.ts
+++ b/src/textmateProvider.ts
@@ -168,10 +168,12 @@ export class TextmateProvider extends BaseProvider {
       }
       for (let item of snippets) {
         let p = path.join(extension.extensionPath, item.path)
-        let { language } = item
-        def.snippets.push({
-          languageId: language,
-          filepath: p
+        let languages = typeof item.language == 'string' ? [item.language] : item.language
+        languages.forEach((language: string) => {
+          def.snippets.push({
+            languageId: language,
+            filepath: p
+          })
         })
       }
       if (snippets && snippets.length) {


### PR DESCRIPTION
Make the array supported by `contributes.snippets[].language`. Then, we can use [rafamadriz/friendly-snippets](https://github.com/rafamadriz/friendly-snippets) as normal.