### PR TITLE
add execContext-option to enable context-execution for completion

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -193,6 +193,7 @@ some regex patterns can't be supported by javascript, including
 - `snippets.userSnippetsDirectory`, Directory that contains custom user ultisnips snippets, use ultisnips in extension root by default.
 - `snippets.shortcut`, shortcut in completion menu, default `S`.
 - `snippets.autoTrigger`: enable auto trigger for auto trigger ultisnips snippets, default `true`.
+- `snippets.execContext`: execute a snippet's `context` (if it exists) to check if the snippet should be shown in completion menu, default `false` (i.e., snippets with a `context` are never shown in completion menu)
 - `snippets.triggerCharacters`: trigger characters for completion, default `[]`.
 - `snippets.loadFromExtensions`: load snippets from coc.nvim extensions, default: `true`.
 - `snippets.loadVSCodeProjectSnippets`: Load code snippets in folder `${workspaceFolder}/.vscode`, default: `true`.

--- a/package.json
+++ b/package.json
@@ -113,6 +113,11 @@
           "default": true,
           "description": "Enable trigger auto trigger snippet after type character."
         },
+        "snippets.execContext": {
+          "type": "boolean",
+          "default": false,
+          "description": "Execute a snippet's context (if it exists) to check if the snippet should be shown in completion menu"
+        },
         "snippets.ultisnips.enable": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
Resolves #333.  
I mainly used code that was removed in b0ab744ab73b599b24276d87f3d80f37cf76f0e8 and added documentation and the option `snippets.execContext`. Its default value is `false`, so the default behavior of coc-snippets doesn't change.

If you're not interested in this, that's fine, but I find it very useful. Either way, I left a comment on #333, so if other people also like this, they could always just use my fork.