### PR TITLE
fix snippets.editSnippets command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export async function activate(context: ExtensionContext): Promise<API> {
     let provider = new UltiSnippetsProvider(channel, c, context)
     manager.regist(provider, 'ultisnips')
 
-    subscriptions.push(commands.registerCommand('snippets.editSnippets', provider.editSnippets))
+    subscriptions.push(commands.registerCommand('snippets.editSnippets', provider.editSnippets.bind(provider)))
   }
 
   if (configuration.loadFromExtensions || configuration.textmateSnippetsRoots?.length > 0) {


### PR DESCRIPTION
The `snippets.editSnippets` and `<Plug>(coc-convert-snippet)` were failing at `this` reference: https://github.com/neoclide/coc-snippets/blob/415026bb21c6752058639f46da40ab5d80f8135d/src/ultisnipsProvider.ts#L354

Binding the provider at command registration fixes it.