### PR TITLE
test: add regression test for snippet session surviving typing (#360)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "esbuild": "^0.25.0",
         "jsonc-parser": "^3.0.0",
         "merge": "^2.1.1",
-        "minimatch": "^5.0.1",
+        "minimatch": "^5.1.8",
         "typescript": "^6.0.3"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "esbuild": "^0.25.0",
     "jsonc-parser": "^3.0.0",
     "merge": "^2.1.1",
-    "minimatch": "^5.0.1",
+    "minimatch": "^5.1.8",
     "typescript": "^6.0.3"
   }
 }

--- a/test/issue360.test.ts
+++ b/test/issue360.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import { before, describe, it } from 'node:test'
+import { commands, snippetManager, workspace } from 'coc.nvim'
+import fs from 'node:fs'
+import path from 'node:path'
+import { openBuffer, waitFor, waitProviderInit } from './helper'
+
+const fixturesDir = path.resolve(process.cwd(), 'test', 'fixtures')
+
+describe('snippet session survives typing', () => {
+  let bufnr: number
+
+  before(async () => {
+    let nvim = workspace.nvim
+    await waitProviderInit()
+    await new Promise<void>(resolve => {
+      let d = workspace.onDidRuntimePathChange(() => {
+        d.dispose()
+        resolve()
+      })
+      void nvim.command(`execute 'set rtp+='.fnameescape('${fixturesDir}')`)
+    })
+    let doc = await openBuffer()
+    bufnr = doc.bufnr
+    await nvim.command('setf javascript')
+    await waitFor(() => doc.filetype == 'javascript')
+    await commands.executeCommand('snippets.addFiletypes', 'javascript')
+  })
+
+  it('keeps the session active and jump works after inserting text', async () => {
+    let nvim = workspace.nvim
+    await nvim.command('call setline(1, "")')
+    await nvim.call('feedkeys', ['Afortest', 'in'])
+    await nvim.call('coc#rpc#request', ['doKeymap', ['coc-snippets-expand']])
+    await waitFor(() => {
+      let session = snippetManager.getSession(bufnr)
+      return !!session && session.isActive
+    })
+    assert.equal(await nvim.eval('coc#status()'), 'SNIP')
+    // type a character at the cursor inside the snippet, like a user who
+    // selects a completion item and keeps typing
+    await nvim.call('feedkeys', ['x', 'in'])
+    await waitFor(() => {
+      let session = snippetManager.getSession(bufnr)
+      return !!session && session.isActive
+    })
+    assert.equal(await nvim.eval('coc#status()'), 'SNIP')
+    await nvim.call('coc#rpc#request', ['doKeymap', ['coc-snippets-expand-jump']])
+    await waitFor(async () => {
+      let pos = await nvim.eval('[line("."), col(".")]') as [number, number]
+      return pos[0] == 3
+    })
+  })
+})


### PR DESCRIPTION
Closes #360.

The reported failure — typing while a completion item is selected kills the snippet session and breaks `snippets-expand-jump` — could not be reproduced on current versions. The snippet session machinery was reworked in coc.nvim 0.0.82.

This PR adds a regression test that locks in the verified behavior: after expanding a snippet, typing at the cursor keeps the session active (`coc#status()` stays `SNIP`) and `snippets-expand-jump` still moves to the next placeholder.

Verified on both Neovim and Vim through coc-test.