### PR TITLE
feat: editSnippets chooses related snippet file by filetypes (#377)

### DIFF
--- a/src/ultisnipsProvider.ts
+++ b/src/ultisnipsProvider.ts
@@ -322,23 +322,36 @@ export class UltiSnippetsProvider extends BaseProvider {
     return directories
   }
 
-  private async getFiletype(): Promise<string> {
+  /**
+   * Filetypes related to current buffer, base filetype first followed by
+   * filetypes from b:coc_snippets_filetypes, falls back to `all`.
+   */
+  private async getEditFiletypes(): Promise<string[]> {
     let buf = await workspace.nvim.buffer
-    if (buf) {
-      let doc = workspace.getDocument(buf.id)
-      if (doc) return doc.filetype
+    let doc = buf ? workspace.getDocument(buf.id) : null
+    let res: string[] = []
+    if (doc && doc.filetype) {
+      res.push(doc.filetype)
+      for (let ft of getAdditionalFiletype(doc.bufnr)) {
+        if (!res.includes(ft)) res.push(ft)
+      }
     }
-    return null
+    return res.length > 0 ? res : ['all']
   }
 
   public async editSnippets(text?: string): Promise<void> {
     const configuration = workspace.getConfiguration('snippets')
-    let filetype = await this.getFiletype()
-    filetype = filetype ?? 'all'
-    filetype = filetype.indexOf('.') == -1 ? filetype : filetype.split('.')[0]
     const snippetsDir = await getSnippetsDirectory(configuration)
     let { nvim } = workspace
-    let file = path.join(snippetsDir, `${filetype}.snippets`)
+    let filetypes = await this.getEditFiletypes()
+    let file: string
+    if (filetypes.length == 1) {
+      file = path.join(snippetsDir, `${filetypes[0]}.snippets`)
+    } else {
+      let files = filetypes.map(ft => path.join(snippetsDir, `${ft}.snippets`))
+      file = await window.showQuickPick(files, { title: 'choose snippet file:' })
+      if (!file) return
+    }
     if (!fs.existsSync(file)) {
       await util.promisify(fs.writeFile)(file, documentation, 'utf8')
     }

--- a/test/editSnippets.test.ts
+++ b/test/editSnippets.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { after, before, describe, it } from 'node:test'
+import { commands, window, workspace } from 'coc.nvim'
+import { openBuffer, waitFor } from './helper'
+
+describe('snippets.editSnippets', () => {
+  let originalPick: any
+
+  before(() => {
+    originalPick = window.showQuickPick
+  })
+
+  after(() => {
+    window.showQuickPick = originalPick
+  })
+
+  async function markdownBuffer(): Promise<void> {
+    let doc = await openBuffer()
+    await workspace.nvim.command('setf markdown')
+    await waitFor(() => doc.filetype == 'markdown')
+  }
+
+  it('opens the snippet file of the current filetype directly', async () => {
+    await markdownBuffer()
+    await commands.executeCommand('snippets.editSnippets')
+    await waitFor(async () => {
+      return await workspace.nvim.eval('expand("%:t")') == 'markdown.snippets'
+    })
+  })
+
+  it('lists all related snippet files when additional filetypes exist', async () => {
+    await markdownBuffer()
+    await commands.executeCommand('snippets.addFiletypes', 'tex', 'mermaid')
+    let items: string[] = []
+    window.showQuickPick = (async (list: string[]) => {
+      items = list
+      return list[1]
+    }) as any
+    await commands.executeCommand('snippets.editSnippets')
+    assert.equal(items.length, 3)
+    assert.ok(items[0].endsWith('markdown.snippets'))
+    assert.ok(items[1].endsWith('tex.snippets'))
+    assert.ok(items[2].endsWith('mermaid.snippets'))
+    await waitFor(async () => {
+      return await workspace.nvim.eval('expand("%:t")') == 'tex.snippets'
+    })
+  })
+
+  it('does not jump when the picker is cancelled', async () => {
+    await markdownBuffer()
+    await commands.executeCommand('snippets.addFiletypes', 'tex')
+    let before: string
+    window.showQuickPick = (async (list: string[]) => {
+      before = await workspace.nvim.eval('expand("%:t")') as string
+      return null
+    }) as any
+    await commands.executeCommand('snippets.editSnippets')
+    assert.equal(await workspace.nvim.eval('expand("%:t")'), before)
+  })
+})


### PR DESCRIPTION
Closes #377.

When the current buffer has additional filetypes from `b:coc_snippets_filetypes` (e.g. `autocmd BufRead *.md let b:coc_snippets_filetypes = ['tex', 'mermaid']`), `snippets.editSnippets` now shows a picker listing the snippet files of all related filetypes — `markdown.snippets`, `tex.snippets`, `mermaid.snippets` — and opens the selected one (creating it with the documentation header when missing).

With a single filetype the snippet file is opened directly, preserving the previous behavior.

Tests:
- opens the snippet file of the current filetype directly
- lists all related snippet files when additional filetypes exist and opens the selected one
- does not jump when the picker is cancelled

Verified on Neovim and Vim through coc-test (full suite 13/13 on both).