### PR TITLE
docs: add FAQ about getting debug output from snippets (#378)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -242,6 +242,20 @@ which does not require the completion menu.
 
 **A:** Use command `:CocCommand workspace.showOutput snippets`
 
+**Q:** How to get debug output from snippets?
+
+**A:** Enable tracing with `snippets.ultisnips.trace: true`,
+`snippets.snipmate.trace: true`, `snippets.massCode.trace: true` or
+`snippets.trace: "verbose"` (textmate snippets), then open the snippets output
+channel with `:CocCommand snippets.openOutput`. Exceptions thrown in UltiSnips
+python interpolation are always caught and appended to the channel with the
+stack trace. To log custom info from interpolation code without throwing, write
+to a file from the python code, e.g.:
+
+```python
+open('/tmp/ultisnips.log', 'a').write('debug info\n')
+```
+
 **Q:** Some ultisnips snippet not works as expected.
 
 **A:** Reformat after change of placeholder feature can't be supported for now,


### PR DESCRIPTION
Closes #378.

Adds a FAQ entry explaining how to get debug output from snippets:

- trace settings per provider (`snippets.ultisnips.trace`, `snippets.snipmate.trace`, `snippets.massCode.trace`, `snippets.trace: "verbose"` for textmate);
- opening the snippets output channel with `:CocCommand snippets.openOutput`;
- that exceptions thrown in UltiSnips python interpolation are always caught and appended to the channel with the stack trace;
- writing to a file from interpolation code for custom debug info without throwing.